### PR TITLE
Make sed command portable across OS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@babel/preset-env": "^7.23.9",
         "@vitest/browser": "^1.3.1",
         "@vitest/utils": "^1.3.1",
-        "babel-plugin-search-and-replace": "^1.1.1",
         "babel-plugin-transform-import-meta": "^2.2.1",
         "prettier": "^3.2.5",
         "tsx": "^4.7.1",
@@ -3147,12 +3146,6 @@
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
-    },
-    "node_modules/babel-plugin-search-and-replace": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-search-and-replace/-/babel-plugin-search-and-replace-1.1.1.tgz",
-      "integrity": "sha512-fjP2VTF3mxxOUnc96mdK22llH92A6gu7A5AFapJmgnqsQi3bqLduIRP0FpA2r5vRZOYPpnX4rE5izQlpsMBjSA==",
-      "dev": true
     },
     "node_modules/babel-plugin-transform-import-meta": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "npm run build:ts && npm run transpileCJS && npm run fixRequire",
     "build:ts": "scripts/ts-build.sh",
-    "transpileCJS": "rm dist/cjs/wasm/kzg.js && babel src/wasm/kzg.js -d dist/cjs/wasm ",
-    "fixRequire": "sed -i \"s/\\_require('url')/require('url')/g\" dist/cjs/wasm/kzg.js",
+    "transpileCJS": "rm dist/cjs/wasm/kzg.js && babel src/wasm/kzg.js -d dist/cjs/wasm",
+    "fixRequire": "sed -i.bak \"s/\\_require('url')/require('url')/g\" dist/cjs/wasm/kzg.js && rm dist/cjs/wasm/kzg.js.bak",
     "clean": "rm -rf dist && rm -rf node_modules",
     "test": "vitest run test/*",
     "test:browser": "npx vitest run -c vitest.config.browser.ts test/*",
@@ -29,7 +29,6 @@
     "@babel/preset-env": "^7.23.9",
     "@vitest/browser": "^1.3.1",
     "@vitest/utils": "^1.3.1",
-    "babel-plugin-search-and-replace": "^1.1.1",
     "babel-plugin-transform-import-meta": "^2.2.1",
     "prettier": "^3.2.5",
     "tsx": "^4.7.1",

--- a/vitest.config.browser.ts
+++ b/vitest.config.browser.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vitest/config'
 import wasm from 'vite-plugin-wasm'
-import topLevelAwait from 'vite-plugin-top-level-await'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 const config = defineConfig({


### PR DESCRIPTION
Fixes a bug in the `sed` command to make it portable across Linux and MacOS